### PR TITLE
Introduce PublicKeyFingerprint for requester

### DIFF
--- a/USAGE.rst
+++ b/USAGE.rst
@@ -24,11 +24,11 @@ Here's a sample requester config file. The default location for this is
 $HOME/.ssh_ca/requester_config.json ::
     {
         "stage": {
-            "PublicKeyPath": "/Users/bvanzant/.ssh/bvanzant-stage.pub",
+            "PublicKeyFingerprint": "17:04:57:a6:b8:49:94:ab:ca:0f:5e:60:8e:6d:e0:df",
             "SignerUrl": "http://ssh-ca:8080/"
         },
         "prod": {
-            "PublicKeyPath": "/Users/bvanzant/.ssh/bvanzant-prod.pub",
+            "PublicKeyFingerprint": "00:f3:ce:02:e7:63:77:dc:65:be:c5:24:ee:1d:63:c0",
             "SignerUrl": "http://ssh-ca:8080/"
         }
     }

--- a/request_cert.go
+++ b/request_cert.go
@@ -131,6 +131,11 @@ func requestCert(c *cli.Context) {
 		pubKeyComment = "unknown"
 	}
 
+	if chosenKeyFingerprint == "" {
+		fmt.Println("No SSH fingerprint found. Try setting PublicKeyFingerprint in requester config.")
+		os.Exit(1)
+	}
+
 	conn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 	if err != nil {
 		fmt.Println("Dial failed:", err)

--- a/util/config.go
+++ b/util/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type RequesterConfig struct {
-	PublicKeyPath string
-	SignerUrl     string
+	PublicKeyPath        string
+	PublicKeyFingerprint string
+	SignerUrl            string
 }
 
 type SignerdConfig struct {


### PR DESCRIPTION
Prior to this commit, for some reason, all config files that dealt with
public keys did so by referencing fingerprints. For some reason I chose
to have the requester config use a path to a public key instead of a
fingerprint. This made ~zero sense.

With this change we now require only a fingerprint and this is the
preferred way of doing things. Documentation has been updated to show
the fingerprint option rather than the path option. The Path option
continues to work for backwards compatibility.