### PR TITLE
JSON API improvements

### DIFF
--- a/sign_certd.go
+++ b/sign_certd.go
@@ -417,6 +417,7 @@ func (h *certRequestHandler) listEnvironments(rw http.ResponseWriter, req *http.
 		return
 	}
 	log.Printf("List environments received from '%s'\n", req.RemoteAddr)
+	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 	rw.Write(result)
 }
 
@@ -466,6 +467,7 @@ func (h *certRequestHandler) listPendingRequests(rw http.ResponseWriter, req *ht
 			http.Error(rw, fmt.Sprintf("Trouble marshaling json response %v", err), http.StatusInternalServerError)
 			return
 		}
+		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 		rw.Write(output)
 	} else {
 		http.Error(rw, fmt.Sprintf("No certs found."), http.StatusNotFound)


### PR DESCRIPTION
Following PR adds the following functionality:

* Updates the `listResponseElement` struct to include the fully marshalled Certificate object, Rejected status, request Environment, and request Reason.
* For HTTP responses that return JSON data, set the Content-Type header to reflect this.
* Add a command line boolean switch (and environment variable) to `runserver` to support running ssh-cert-authority behind a reverse proxy such as Nginx. When running in reverse-proxy mode, Gorilla's [ProxyHeaders](http://www.gorillatoolkit.org/pkg/handlers#ProxyHeaders) middleware is used to inspect `X-Forwarded-For` and/or `X-Real-IP` headers to update the remote address on the request object accordingly (along with other information).