### PR TITLE
Add explicit checks during cert validation and unit tests

### DIFF
--- a/sign_certd.go
+++ b/sign_certd.go
@@ -377,6 +377,18 @@ func (h *certRequestHandler) validateCert(cert *ssh.Certificate, authorizedSigne
 		err := fmt.Errorf("Cert not valid: %v", err)
 		return err
 	}
+
+	if cert.CertType != ssh.UserCert {
+		err = errors.New("Cert not valid: not a user certificate")
+		return err
+	}
+
+	// explicitly call IsUserAuthority
+	if !certChecker.IsUserAuthority(cert.SignatureKey) {
+		err = errors.New("Cert not valid: not signed by an authorized key")
+		return err
+	}
+
 	return nil
 }
 

--- a/sign_certd_test.go
+++ b/sign_certd_test.go
@@ -277,6 +277,34 @@ func TestSaveRequestValidCriticalOptions(t *testing.T) {
 	}
 }
 
+func TestValidateCert(t *testing.T) {
+	allConfig := SetupSignerdConfig(1, 0)
+	environment := "testing"
+	envConfig := allConfig[environment]
+	requestHandler := makeCertRequestHandler(allConfig)
+
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(boringUserCertString))
+	if err != nil {
+		t.Fatalf("Parsing canned cert failed: %v", err)
+	}
+	cert := pubKey.(*ssh.Certificate)
+
+	// test-user is *not* in the list of authorized signers
+
+	err = requestHandler.validateCert(cert, envConfig.AuthorizedSigners)
+
+	if err == nil {
+		t.Fatalf("Should have failed. Succeeded with: %v", err)
+	}
+
+	// test-user *is* in the list of authorized users
+
+	err = requestHandler.validateCert(cert, envConfig.AuthorizedUsers)
+	if err != nil {
+		t.Fatalf("Should have succeeded. Failed with: %v", err)
+	}
+}
+
 func getTwoBoringCerts(t *testing.T) (*ssh.Certificate, *ssh.Certificate) {
 	pubKeyOne, _, _, _, err := ssh.ParseAuthorizedKey([]byte(boringUserCertString))
 	if err != nil {


### PR DESCRIPTION
In a commit to upstream [`x/crypto/ssh`](https://github.com/golang/crypto/commit/7e9105388ebff089b3f99f0ef676ea55a6da3a7e), the `CheckCert` function of `ssh.CertChecker` interface no longer calls `IsUserAuthority` function here.

Not calling the function we assign to `IsUserAuthority` here results in a security vulnerability allowing _any_ SSH key signature (other than that of the requester's) to sign a certificate request. A requester may bypass m-of-n controls by generating a new key and signing their own request with that key.

This PR mitigates this vulnerability by explicitly calling the `IsUserAuthority` function.