### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/signer/gcpkms.go
+++ b/signer/gcpkms.go
@@ -60,7 +60,7 @@ func NewGcpKmsSigner(keyUrl string) (*GcpKmsSigner, error) {
 	return kmsSigner, nil
 }
 
-// PublicKey returns an associated PublicKey instance.
+// Public returns an associated PublicKey instance.
 func (g GcpKmsSigner) Public() crypto.PublicKey {
 	return g.kmsPubKey
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?