### PR TITLE
Flag fix

### DIFF
--- a/get_cert.go
+++ b/get_cert.go
@@ -28,7 +28,7 @@ func getCertFlags() []cli.Flag {
 			Usage: "An environment name (e.g. prod)",
 		},
 		cli.StringFlag{
-			Name:  "config-file",
+			Name:  "config-file, c",
 			Value: configPath,
 			Usage: "Path to config.json",
 		},

--- a/sign_certd.go
+++ b/sign_certd.go
@@ -690,7 +690,7 @@ func signdFlags() []cli.Flag {
 
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  "config-file",
+			Name:  "config-file, c",
 			Value: configPath,
 			Usage: "Path to config.json",
 		},


### PR DESCRIPTION
Seems `-c` isn't universally valid as a short form for `--config-file`; I've added it to "get" and "runserver."